### PR TITLE
fix: correct --output-dir shorthand and fix NormalizeVolumePath missing in recover command

### DIFF
--- a/cmd/cmd/recover.go
+++ b/cmd/cmd/recover.go
@@ -45,7 +45,7 @@ Recovered files will be saved to the specified output directory.`,
 		SilenceUsage: true,
 		RunE:         RunRecover,
 	}
-	cmd.Flags().StringP("output-dir", "i", "", "Absolute path to the directory where recovered data will be placed.")
+        cmd.Flags().StringP("output-dir", "o", "", "Absolute path to the directory where recovered data will be placed.")
 	return cmd
 }
 

--- a/cmd/cmd/recover.go
+++ b/cmd/cmd/recover.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ostafen/digler/internal/scan"
 	"github.com/ostafen/digler/pkg/dfxml"
 	osutils "github.com/ostafen/digler/pkg/util/os"
+	disk "github.com/ostafen/digler/pkg/util/disk"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +51,8 @@ Recovered files will be saved to the specified output directory.`,
 }
 
 func RunRecover(cmd *cobra.Command, args []string) error {
-	f, err := fs.Open(args[0])
+		path := disk.NormalizeVolumePath(args[0])
+	f, err := fs.Open(path)
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd/recover.go
+++ b/cmd/cmd/recover.go
@@ -25,12 +25,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ostafen/digler/internal/disk"
 	"github.com/ostafen/digler/internal/fs"
 	"github.com/ostafen/digler/internal/logger"
 	"github.com/ostafen/digler/internal/scan"
 	"github.com/ostafen/digler/pkg/dfxml"
 	osutils "github.com/ostafen/digler/pkg/util/os"
-	disk "github.com/ostafen/digler/pkg/util/disk"
 	"github.com/spf13/cobra"
 )
 
@@ -46,12 +46,12 @@ Recovered files will be saved to the specified output directory.`,
 		SilenceUsage: true,
 		RunE:         RunRecover,
 	}
-        cmd.Flags().StringP("output-dir", "o", "", "Absolute path to the directory where recovered data will be placed.")
+	cmd.Flags().StringP("output-dir", "o", "", "Absolute path to the directory where recovered data will be placed.")
 	return cmd
 }
 
 func RunRecover(cmd *cobra.Command, args []string) error {
-		path := disk.NormalizeVolumePath(args[0])
+	path := disk.NormalizeVolumePath(args[0])
 	f, err := fs.Open(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Bug Fix

The --output-dir flag in the recover command was registered with the shorthand -i (typically used for "input"), which is incorrect and misleading for an output directory flag.

### Change
- **File**: cmd/cmd/recover.go
- - **Line 49**: Changed shorthand from "i" to "o"
### Before
```go
cmd.Flags().StringP("output-dir", "i", "", "Absolute path to the directory where recovered data will be placed.")
```

### After
```go
cmd.Flags().StringP("output-dir", "o", "", "Absolute path to the directory where recovered data will be placed.")
```